### PR TITLE
Bug fix - class_list throwing error

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,7 @@
+=== 1.0.1 / 2020-06-28
+
+* Fixing bug with class_list method caused by upgrading the yard plugin
+
 === 1.0.0 / 2020-06-28
 
 * Forked from yard-cucumber and renamed yard-gherkin-turnip

--- a/lib/templates/default/fulldoc/html/setup.rb
+++ b/lib/templates/default/fulldoc/html/setup.rb
@@ -163,7 +163,7 @@ end
 # This method removes the namespace from the root node, generates the class list,
 # and then adds it back into the root node.
 #
-def class_list(root = Registry.root, tree = TreeContext.new)
+def class_list(root = Registry.root, tree = nil)
   return super unless root == Registry.root
 
   cucumber_namespace = YARD::CodeObjects::Cucumber::CUCUMBER_NAMESPACE

--- a/lib/yard-gherkin-turnip/version.rb
+++ b/lib/yard-gherkin-turnip/version.rb
@@ -1,3 +1,3 @@
 module YardTurnip
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end


### PR DESCRIPTION
Bumping the version of YARD caused the overriden class_list method to
fall over as it has no TreeContext class defined.  As the paramter is
unused, this now defaults to nil.